### PR TITLE
Save a couple of copies and a heap allocation.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -8,7 +8,7 @@ import (
 
 var LayoutDir string = "generator"
 
-func Run(s io.Writer, a completions.AutoComplete) {
+func Run(s io.Writer, a *completions.AutoComplete) {
 	tmpl, err := template.ParseGlob(LayoutDir + "/*.gotmpl")
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -21,10 +21,10 @@ func main() {
 
 	p := persister.NewDiskPersister()
 
-	var gcloudDocs completions.AutoComplete
-	err = p.Load(cacheFile, &gcloudDocs)
+	gcloudDocs := &completions.AutoComplete{}
+	err = p.Load(cacheFile, gcloudDocs)
 	if err != nil {
-		gcloudDocs = *scrapper.Run()
+		scrapper.Run(gcloudDocs)
 		p.Save(cacheFile, gcloudDocs)
 	}
 

--- a/scrapper/scrapper.go
+++ b/scrapper/scrapper.go
@@ -11,14 +11,14 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-func Run() *completions.AutoComplete {
+func Run(gcloudDocs *completions.AutoComplete) {
 	groups, commands, flags := parsePage("https://cloud.google.com/sdk/gcloud/reference/")
 
 	// this should be recursive not just one deep it could use go routines im sure google can handle it
 	// and there are alot of them :P
 	populateGroups(groups)
 
-	return &completions.AutoComplete{
+	*gcloudDocs = completions.AutoComplete{
 		Name:        "gcloud",
 		Description: "gcloud bla bla bla",
 		Groups:      groups,


### PR DESCRIPTION
Deferencing the scraper result copies the data locally, which is then
passed by value (another copy) to the generator. Putting it on the heap
to start with saves having to do either.

We save an extra heap allocation by passing the address to `scrapper.Run`.